### PR TITLE
[Doppins] Upgrade dependency fake-factory to ==0.5.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ pylint==1.6.4
 six==1.10.0
 ipaddress==1.0.16
 python-dateutil==2.5.3
-fake-factory==0.5.9
+fake-factory==0.5.10
 factory_boy==2.7.0
 sqlparse==0.2.0
 pycrypto==2.6.1


### PR DESCRIPTION
Hi!

A new version was just released of `fake-factory`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded fake-factory from `==0.5.9` to `==0.5.10`

